### PR TITLE
Add aarch64-darwin build dependencies to Nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,13 @@
       in
       rec {
         devShell = pkgs.mkShell {
-          buildInputs = with pkgs; [ rustup rust-analyzer ];
+          buildInputs = with pkgs; [
+            rustup
+            rust-analyzer
+          ]
+          ++ lib.optionals (system == "aarch64-darwin") [
+            libiconv
+          ];
         };
       }
     );


### PR DESCRIPTION
Linking fails on ARM64 Macs without `libiconv`:

```
ld: library not found for -liconv
clang-11: error: linker command failed with exit code 1 (use -v to see invocation)
```